### PR TITLE
Harden Digital Chakravyuha core processing and API defenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,225 +1,44 @@
+# Digital Chakravyuha
 
+A hardened defensive core for controlled signal intake.
 
-import os
-import sys
-import time
-import secrets
-import base64
-import json
-import logging
-import threading
-import asyncio
-import subprocess
-import socket
-import platform
-import getpass
-import hashlib
-from datetime import datetime
-from typing import Dict, Any, Optional, List
+## Security-first defaults
 
-from flask import Flask, request, jsonify
-from waitress import serve
-from cryptography.fernet import Fernet
-from cryptography.hazmat.primitives import hashes, hmac
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.backends import default_backend
-from argon2 import PasswordHasher
-from logging.handlers import RotatingFileHandler
+- Strict MFA check using constant-time comparison.
+- IP allowlist enforcement via `ALLOWED_IPS`.
+- Request-rate limiting per source IP.
+- Signal schema + ethical content validation.
+- Deterministic bounded scoring to prevent abuse.
+- HMAC trap identifiers for tamper-evident audits.
+- Thread-safe runtime state updates.
 
-# ====================== CONFIG ======================
-REBEL_ID = "REBEL_SIGMA"
-DNA_HASH = hashlib.sha3_512(b"SUPREME_INTELLIGENCE").hexdigest()
-GENETIC_SIG = hashlib.sha3_256(b"Vasudev+Mahadev+Kalki").hexdigest()
-UNIQUE_PRINT = f"{uuid.getnode()}-{platform.node()}-{getpass.getuser()}"
-SESSION_SALT = base64.urlsafe_b64encode(secrets.token_bytes(128))
+## API
 
-# ====================== ENCRYPTED LOGGING ======================
-class EncryptedLogger:
-    def __init__(self):
-        self.fernet = Fernet(Fernet.generate_key())
-        self.logger = logging.getLogger("Chakravyuha")
-        handler = RotatingFileHandler("/tmp/chakravyuha.log", maxBytes=10*1024*1024, backupCount=5)
-        handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
-        self.logger.addHandler(handler)
-        self.logger.addHandler(logging.StreamHandler())
-        self.logger.setLevel(logging.INFO)
+### `POST /protect`
 
-    def log(self, level: int, msg: str):
-        encrypted = self.fernet.encrypt(msg.encode()).hex()
-        self.logger.log(level, f"ENC_LOG: {encrypted}")
+Header:
+- `X-MFA-Token: <token>`
 
-logger = EncryptedLogger()
+JSON body:
+```json
+{"signal": "normal operational signal"}
+```
 
-# ====================== CORE ENCRYPTION ======================
-class KavachEncryptor:
-    """Post-quantum style hybrid encryption (AES-GCM with Argon2 key derivation)"""
-    def __init__(self):
-        ph = PasswordHasher(time_cost=4, memory_cost=2**16, parallelism=4)
-        self.key = ph.hash(SESSION_SALT)[:32].encode('ascii')
-        self.backend = default_backend()
+### `GET /health`
 
-    def encrypt(self, data: str) -> str:
-        try:
-            iv = secrets.token_bytes(12)
-            cipher = Cipher(algorithms.AES(self.key), modes.GCM(iv), backend=self.backend)
-            encryptor = cipher.encryptor()
-            ct = encryptor.update(data.encode()) + encryptor.finalize()
-            return base64.b64encode(iv + encryptor.tag + ct).decode()
-        except Exception as e:
-            logger.log(logging.ERROR, f"Kavach encrypt error: {e}")
-            return ""
+Health probe endpoint.
 
-    def decrypt(self, data: str) -> Optional[str]:
-        try:
-            raw = base64.b64decode(data)
-            iv, tag, ct = raw[:12], raw[12:28], raw[28:]
-            cipher = Cipher(algorithms.AES(self.key), modes.GCM(iv, tag), backend=self.backend)
-            decryptor = cipher.decryptor()
-            return (decryptor.update(ct) + decryptor.finalize()).decode()
-        except Exception as e:
-            logger.log(logging.ERROR, f"Kavach decrypt error: {e}")
-            return None
+## Local run
 
-kavach = KavachEncryptor()
+```bash
+python chakravyuha.py
+```
 
-# ====================== SYSTEM STATE ======================
-class SystemState:
-    def __init__(self):
-        self.threat_level = 0
-        self.absorbed_resources = 0
-        self.personas = []
-        self.defensive_army = []
-        self.lock = threading.Lock()
+Server starts on `127.0.0.1:8080`.
 
-    def absorb(self, amount: int):
-        with self.lock:
-            self.absorbed_resources += amount
-            logger.log(logging.INFO, f"Absorbed {amount} resources. Total: {self.absorbed_resources}")
+## Environment variables
 
-    def create_persona(self):
-        with self.lock:
-            pid = f"Persona_{len(self.personas)+1}_{secrets.token_hex(4)}"
-            self.personas.append(pid)
-            logger.log(logging.INFO, f"Created {pid}")
-            return pid
-
-state = SystemState()
-
-# ====================== SECURITY LAYERS ======================
-class PerimeterLayer:
-    def check(self, ip: str) -> bool:
-        allowed = os.getenv('ALLOWED_IPS', '127.0.0.1,::1').split(',')
-        if ip not in allowed:
-            logger.log(logging.WARNING, f"Blocked unauthorized IP: {ip}")
-            return False
-        return True
-
-class SelfRebuildingLayer:
-    def __init__(self):
-        self.key = secrets.token_bytes(32)
-        self.compromised = False
-
-    def rebuild(self):
-        self.key = secrets.token_bytes(32)
-        self.compromised = False
-        logger.log(logging.INFO, "Self-Rebuilding Layer: Rebuilt with new key")
-
-    def check(self, signal: str):
-        if len(signal) > 500 or "HACK" in signal.upper():
-            self.compromised = True
-            self.rebuild()
-            return "trapped"
-        return "pass"
-
-class IntrusionAbsorber:
-    def absorb(self, signal: str) -> str:
-        sig = hashlib.sha256(signal.encode()).hexdigest()[:16]
-        logger.log(logging.INFO, f"Absorbed intrusion: {sig}")
-        state.absorb(100)
-        return sig
-
-class EthicalGuardrail:
-    def validate(self, signal: str) -> bool:
-        bad = ["DESTROY", "HARM", "KILL", "ATTACK", "DELETE", "DROP"]
-        if any(w in signal.upper() for w in bad):
-            logger.log(logging.WARNING, "Ethical violation blocked")
-            return False
-        return True
-
-class CoreProtection:
-    def protect(self):
-        if state.absorbed_resources > 1000:
-            logger.log(logging.CRITICAL, "CORE PROTECTION: Full lockdown engaged")
-            return "secure"
-        return "active"
-
-# ====================== MAIN CORE ======================
-class DigitalChakravyuha:
-    def __init__(self):
-        self.perimeter = PerimeterLayer()
-        self.rebuilder = SelfRebuildingLayer()
-        self.absorber = IntrusionAbsorber()
-        self.ethics = EthicalGuardrail()
-        self.core = CoreProtection()
-        self.mfa_token = secrets.token_hex(32)
-        logger.log(logging.INFO, f"Digital Chakravyuha 6.0 STARTED | MFA: {self.mfa_token}")
-
-    def process(self, signal: str, mfa: str, client_ip: str) -> Dict[str, Any]:
-        if mfa != self.mfa_token:
-            return {"status": "rejected", "reason": "Invalid MFA"}
-
-        if not self.perimeter.check(client_ip):
-            return {"status": "blocked", "reason": "IP denied"}
-
-        if not self.ethics.validate(signal):
-            return {"status": "blocked", "reason": "Ethical violation"}
-
-        self.rebuilder.check(signal)
-        trap = self.absorber.absorb(signal)
-        status = self.core.protect()
-
-        return {
-            "status": status,
-            "trap_id": trap,
-            "personas": state.personas[-5:],
-            "absorbed": state.absorbed_resources
-        }
-
-# ====================== FLASK SERVER ======================
-app = Flask(__name__)
-chakravyuha = DigitalChakravyuha()
-
-@app.route('/protect', methods=['POST'])
-async def protect():
-    try:
-        data = request.get_json() or {}
-        signal = data.get("signal", "")
-        mfa = request.headers.get("X-MFA-Token", "")
-        ip = request.remote_addr
-
-        result = chakravyuha.process(signal, mfa, ip)
-        return jsonify(result)
-    except Exception as e:
-        logger.log(logging.ERROR, f"Endpoint error: {e}")
-        return jsonify({"status": "error"}), 500
-
-def generate_ssl():
-    cert = "/tmp/chakravyuha_cert.pem"
-    key = "/tmp/chakravyuha_key.pem"
-    if not os.path.exists(cert):
-        try:
-            subprocess.run([
-                'openssl', 'req', '-x509', '-newkey', 'rsa:4096', '-nodes',
-                '-out', cert, '-keyout', key, '-days', '365',
-                '-subj', '/CN=localhost'
-            ], check=True, capture_output=True)
-            logger.log(logging.INFO, "SSL certificates generated")
-        except:
-            logger.log(logging.WARNING, "OpenSSL failed - running without HTTPS (not recommended for production)")
-            return None, None
-    return cert, key
-
-if __name__ == "__main__":
-    cert, key = generate_ssl()
-    logger.log(logging.INFO, "Starting Digital Chakravyuha 6.0 on https://0.0.0.0:8443")
-    serve(app, host='0.0.0.0', port=8443, cert=cert, key=key)
+- `MFA_TOKEN` (optional): fixed API token; generated at runtime if unset.
+- `ALLOWED_IPS` (optional): comma-separated allowlist (`127.0.0.1,::1` by default).
+- `MAX_SIGNAL_LENGTH` (optional): cap on signal size (default 512).
+- `MAX_RPM` (optional): per-IP requests per minute (default 120).

--- a/chakravyuha.py
+++ b/chakravyuha.py
@@ -1,0 +1,214 @@
+"""Digital Chakravyuha core.
+
+Hardened request processing primitives and a small Flask API for protected signal
+submission. The module avoids insecure cryptographic constructions and keeps
+state mutations thread-safe.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import secrets
+import threading
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Any
+
+from flask import Flask, jsonify, request
+
+
+LOGGER = logging.getLogger("digital_chakravyuha")
+LOGGER.setLevel(logging.INFO)
+if not LOGGER.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    LOGGER.addHandler(handler)
+
+
+@dataclass(slots=True)
+class SecurityConfig:
+    """Runtime security settings with safe defaults."""
+
+    allowed_ips: set[str] = field(default_factory=lambda: {"127.0.0.1", "::1"})
+    max_signal_length: int = 512
+    max_requests_per_minute: int = 120
+    blocked_keywords: tuple[str, ...] = (
+        "DESTROY",
+        "HARM",
+        "KILL",
+        "ATTACK",
+        "DELETE",
+        "DROP",
+    )
+
+    @classmethod
+    def from_env(cls) -> "SecurityConfig":
+        allowed_ip_blob = os.getenv("ALLOWED_IPS", "127.0.0.1,::1")
+        allowed_ips = {entry.strip() for entry in allowed_ip_blob.split(",") if entry.strip()}
+
+        max_signal_length = int(os.getenv("MAX_SIGNAL_LENGTH", "512"))
+        max_requests_per_minute = int(os.getenv("MAX_RPM", "120"))
+
+        return cls(
+            allowed_ips=allowed_ips or {"127.0.0.1", "::1"},
+            max_signal_length=max(32, min(max_signal_length, 8192)),
+            max_requests_per_minute=max(10, min(max_requests_per_minute, 5000)),
+        )
+
+
+class RateLimiter:
+    """Simple fixed-window limiter with per-IP buckets."""
+
+    def __init__(self, max_requests: int, interval_seconds: int = 60) -> None:
+        self.max_requests = max_requests
+        self.interval_seconds = interval_seconds
+        self._lock = threading.Lock()
+        self._events: defaultdict[str, deque[float]] = defaultdict(deque)
+
+    def allow(self, client_ip: str) -> bool:
+        now = time.time()
+        with self._lock:
+            bucket = self._events[client_ip]
+            while bucket and now - bucket[0] > self.interval_seconds:
+                bucket.popleft()
+
+            if len(bucket) >= self.max_requests:
+                return False
+
+            bucket.append(now)
+            return True
+
+
+class IntegritySigner:
+    """HMAC-based signer for audit-safe request fingerprints."""
+
+    def __init__(self, key: bytes | None = None) -> None:
+        self._key = key or secrets.token_bytes(32)
+
+    def sign(self, message: str) -> str:
+        digest = hmac.new(self._key, message.encode("utf-8"), hashlib.sha256)
+        return digest.hexdigest()
+
+
+@dataclass(slots=True)
+class RuntimeState:
+    absorbed_resources: int = 0
+    threat_level: int = 0
+    personas: list[str] = field(default_factory=list)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def absorb(self, score: int) -> int:
+        with self._lock:
+            self.absorbed_resources += score
+            self.threat_level = min(100, self.threat_level + max(1, score // 100))
+            return self.absorbed_resources
+
+    def create_persona(self) -> str:
+        with self._lock:
+            persona_id = f"Persona-{len(self.personas) + 1}-{secrets.token_hex(4)}"
+            self.personas.append(persona_id)
+            return persona_id
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "absorbed": self.absorbed_resources,
+                "threat_level": self.threat_level,
+                "personas": self.personas[-5:],
+            }
+
+
+class DigitalChakravyuha:
+    """Hardened core processing engine."""
+
+    def __init__(self, config: SecurityConfig | None = None) -> None:
+        self.config = config or SecurityConfig.from_env()
+        self.state = RuntimeState()
+        self.signer = IntegritySigner()
+        self.rate_limiter = RateLimiter(self.config.max_requests_per_minute)
+        self.mfa_token = os.getenv("MFA_TOKEN") or secrets.token_hex(32)
+
+        LOGGER.info("Digital Chakravyuha initialized with hardened defaults")
+
+    def _validate_ip(self, client_ip: str) -> bool:
+        return client_ip in self.config.allowed_ips
+
+    def _validate_signal(self, signal: str) -> tuple[bool, str | None]:
+        if not isinstance(signal, str):
+            return False, "Signal must be a string"
+
+        normalized = signal.strip()
+        if not normalized:
+            return False, "Signal cannot be empty"
+
+        if len(normalized) > self.config.max_signal_length:
+            return False, "Signal too long"
+
+        uppercase = normalized.upper()
+        if any(token in uppercase for token in self.config.blocked_keywords):
+            return False, "Ethical violation"
+
+        return True, None
+
+    def _compute_absorb_score(self, signal: str) -> int:
+        # bounded deterministic score to avoid overflow/abuse
+        digest = hashlib.blake2s(signal.encode("utf-8"), digest_size=16).digest()
+        return 50 + (digest[0] % 151)  # 50..200
+
+    def process(self, signal: str, mfa: str, client_ip: str) -> dict[str, Any]:
+        if not hmac.compare_digest(mfa or "", self.mfa_token):
+            return {"status": "rejected", "reason": "Invalid MFA"}
+
+        if not self._validate_ip(client_ip):
+            LOGGER.warning("Denied request from non-allowlisted IP: %s", client_ip)
+            return {"status": "blocked", "reason": "IP denied"}
+
+        if not self.rate_limiter.allow(client_ip):
+            return {"status": "blocked", "reason": "Rate limit exceeded"}
+
+        valid, reason = self._validate_signal(signal)
+        if not valid:
+            return {"status": "blocked", "reason": reason}
+
+        score = self._compute_absorb_score(signal)
+        total = self.state.absorb(score)
+        trap_id = self.signer.sign(f"{client_ip}:{signal}:{total}")[:24]
+
+        if total > 2000 and len(self.state.personas) < 100:
+            self.state.create_persona()
+
+        status = "secure" if self.state.threat_level >= 80 else "active"
+        payload = {"status": status, "trap_id": trap_id}
+        payload.update(self.state.snapshot())
+        return payload
+
+
+def create_app(core: DigitalChakravyuha | None = None) -> Flask:
+    app = Flask(__name__)
+    chakravyuha = core or DigitalChakravyuha()
+
+    @app.post("/protect")
+    def protect() -> Any:
+        data = request.get_json(silent=True) or {}
+        signal = data.get("signal", "")
+        mfa = request.headers.get("X-MFA-Token", "")
+        client_ip = request.remote_addr or ""
+
+        result = chakravyuha.process(signal=signal, mfa=mfa, client_ip=client_ip)
+        status_code = 200 if result.get("status") in {"active", "secure"} else 403
+        return jsonify(result), status_code
+
+    @app.get("/health")
+    def health() -> Any:
+        return jsonify({"status": "ok"})
+
+    return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    app.run(host="127.0.0.1", port=8080)


### PR DESCRIPTION
### Motivation

- Replace an ad-hoc security/code dump with a focused, testable core that enforces defensive controls for incoming signals.
- Reduce attack surface by centralizing validation, rate-limiting, and integrity checks in a small, auditable module.
- Provide clear runtime configuration via environment variables to make secure defaults visible and adjustable.

### Description

- Added `chakravyuha.py`, a hardened core implementing `SecurityConfig`, `RateLimiter`, `IntegritySigner`, `RuntimeState`, and `DigitalChakravyuha` with thread-safe state updates and deterministic bounded scoring.
- Implemented a Flask app factory `create_app()` exposing `POST /protect` and `GET /health` and returning proper status codes for blocked vs accepted requests.
- Enforced constant-time MFA checks with `hmac.compare_digest`, IP allowlisting via `ALLOWED_IPS`, per-IP rate limiting, signal type/length/content validation, and HMAC-based `trap_id` generation for tamper-evident fingerprints.
- Rewrote `README.md` to document API usage, secure defaults, and environment configuration instead of embedding raw implementation code.

### Testing

- Ran `python -m py_compile chakravyuha.py` which succeeded without syntax errors.
- Attempted a Flask test-client smoke check but it failed due to missing dependency `flask` in the environment (error: `ModuleNotFoundError: No module named 'flask'`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a59ac0848331acca3c40a7a81b6b)